### PR TITLE
Remove line and indent from single column, * select

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "env/bin/python3"
+}

--- a/example.py
+++ b/example.py
@@ -1,13 +1,19 @@
 
 import sql_parser
 from format import Formatter
+import argparse
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("filepath")
+args = argparser.parse_args()
 
 parser = sql_parser.BigQueryViewParser()
-sql = """
-with my_cte as (select sum(case when a=1 then 1 else 0 end) as pivoted from table) select * from my_cte
-"""
+
+with open(args.filepath, 'r') as f:
+    sql = f.read()
 
 ast = parser._parse(sql)
+
 f = Formatter()
 f.format(ast)
 f.document.pprint()

--- a/format.py
+++ b/format.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import re
+import pdb
 
 from contextlib import contextmanager
 
@@ -370,17 +371,21 @@ class Formatter:
 
     def columns(self, json):
         self.document.add('select')
-        self.document.newline()
-        with self.document.indented():
-            for i, column in enumerate(json.columns):
-                if self.document.commas == 'front' and i != 0:
-                    self.document.add(', ')
 
-                self.add_column(column)
+        if len(json.columns) == 1 and json.columns[0] == '*':
+            self.document.add(' * ')
+        else:
+            self.document.newline()
+            with self.document.indented():
+                for i, column in enumerate(json.columns):
+                    if self.document.commas == 'front' and i != 0:
+                        self.document.add(', ')
 
-                if self.document.commas == 'back' and i != len(json.columns)-1:
-                    self.document.add(',')
-                self.document.newline()
+                    self.add_column(column)
+
+                    if self.document.commas == 'back' and i != len(json.columns)-1:
+                        self.document.add(',')
+                    self.document.newline()
 
     # This ain't it :/
     def add_from(self, from_):

--- a/query.sql
+++ b/query.sql
@@ -1,0 +1,1 @@
+with my_cte as (select sum(case when a=1 then 1 else 0 end) as pivoted from table) select * from my_cte


### PR DESCRIPTION
I don't know if the convention is to only do this for final select queries, wasn't sure how to implement the logic for that. Instead, if there is ever a single column in a query which is *, we ignore the newlines

```
with my_cte as (

    select
        sum(case
            when a = 1 then 1
            else 0
        end) as pivoted

    from table

)

select *
from my_cte
``` 

instead of

```
with my_cte as (

    select
        sum(case
            when a = 1 then 1
            else 0
        end) as pivoted

    from table

)

select
    *

from my_cte
```